### PR TITLE
Move includes to top

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -33,7 +33,7 @@ categories = YAML.load_file(File.join(File.expand_path(File.dirname(__FILE__)), 
                 
                 <% categories.each do |category, category_parts| %>
                     <%= render_category(category)%>
-                <%end%>
+                <% end %>
 
             </div>
         </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -42,10 +42,11 @@ categories = YAML.load_file(File.join(File.expand_path(File.dirname(__FILE__)), 
     <!-- call jane functions in background on button click -->
     <script>
     function jane(device, func, para){
-        if('undefined' === typeof para){
-            var call = device + "/" + func;
-        }else{
-            var call = device + "/" + func + "/" + para;
+        var call;
+        if ('undefined' === typeof para){
+            call = device + "/" + func;
+        } else {
+            call = device + "/" + func + "/" + para;
         }
         $.get(call);
     }

--- a/views/index.erb
+++ b/views/index.erb
@@ -41,12 +41,10 @@ categories = YAML.load_file(File.join(File.expand_path(File.dirname(__FILE__)), 
     
     <!-- call jane functions in background on button click -->
     <script>
-    function jane(device, func, para){
-        var call;
-        if ('undefined' === typeof para){
-            call = device + "/" + func;
-        } else {
-            call = device + "/" + func + "/" + para;
+    function jane(device, func, param){
+        var call = device + "/" + func;
+        if (!param){
+            call += "/" + param
         }
         $.get(call);
     }

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,4 +1,7 @@
-<!DOCTYPE html>
+<%
+require 'yaml' 
+categories = YAML.load_file(File.join(File.expand_path(File.dirname(__FILE__)), '..', 'config' ,'config.yml'))
+%><!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -21,9 +24,6 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
   </head>
-  <% require 'yaml' 
-  %>
-  <%categories = YAML.load_file(File.join(File.expand_path(File.dirname(__FILE__)), '..', 'config' ,'config.yml'))%>
 
   <body>
     <div class="container">
@@ -39,19 +39,16 @@
         </div>
     </div>
     
-
     <!-- call jane functions in background on button click -->
     <script>
-        
-        function jane(device, func, para){
-            if('undefined' === typeof para){
-                var call = device + "/" + func;
-            }else{
-                var call = device + "/" + func + "/" + para;
-            }
-            $.get(call);
+    function jane(device, func, para){
+        if('undefined' === typeof para){
+            var call = device + "/" + func;
+        }else{
+            var call = device + "/" + func + "/" + para;
         }
-        
+        $.get(call);
+    }
     </script>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->


### PR DESCRIPTION
A little bit of formatting for the view file.

1. You should load stuff before doing the actual rendering. Thus I moved the `require` and `YAML.load_file` to the top. It would be actually better to have this code in your other code and pass it into the view.
2. A bit of formatting for the JS code.