### PR TITLE
Added rufus-scheduler to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source 'https://rubygems.org'
 gem 'whenever'
 gem 'sinatra'
 
+gem 'rufus-scheduler'
+
 # clean code
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,12 +20,17 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.1)
+    rufus-scheduler (3.0.9)
+      tzinfo
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.6.0)
+    thread_safe (0.3.4)
     tilt (1.4.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     whenever (0.9.4)
       chronic (>= 0.6.3)
 
@@ -34,5 +39,6 @@ PLATFORMS
 
 DEPENDENCIES
   rubocop
+  rufus-scheduler
   sinatra
   whenever


### PR DESCRIPTION
The addon `addon/timer.rb` requires `rufus-scheduler`.