### PR TITLE
Set path to jane in environment variable

### DIFF
--- a/jane.rb
+++ b/jane.rb
@@ -5,8 +5,22 @@ require 'net/http'
 require 'rake'
 require 'rack/cache'
 
-require './lib/jane'
-require './lib/command'
+jane_lib =
+  File.expand_path(
+    File.join(
+      ENV['JANE_PATH'], 'lib', 'jane'
+    )
+  )
+
+command =
+  File.expand_path(
+    File.join(
+      ENV['JANE_PATH'], 'lib', 'command'
+    )
+  )
+
+require jane_lib
+require command
 
 # listen to 0.0.0.0 instead of localhost
 set :bind, '0.0.0.0'

--- a/lib/home_check_ping_mod.rb
+++ b/lib/home_check_ping_mod.rb
@@ -4,8 +4,7 @@ module HomeCheckPingMod
   def self.config_file
     File.expand_path(
       File.join(
-        File.dirname(__FILE__),
-        '..', 'config', 'home_check_ping.json'
+        ENV['JANE_PATH'], 'config', 'home_check_ping.json'
       )
     )
   end

--- a/lib/jane.rb
+++ b/lib/jane.rb
@@ -4,18 +4,13 @@ require "json"
 module Jane
   
   def self.path
-    File.expand_path(
-      File.join(
-        File.dirname(__FILE__), '..'
-      )
-    )
+    ENV['JANE_PATH']
   end
   
   def self.config_file
     File.expand_path(
       File.join(
-        File.dirname(__FILE__),
-        '..', 'config', 'config.json'
+        path, 'config', 'config.json'
       )
     )
   end

--- a/lib/sunset.rb
+++ b/lib/sunset.rb
@@ -1,20 +1,20 @@
 # sunset
-jane_lib_path =
+jane_lib =
   File.expand_path(
     File.join(
-      File.dirname(__FILE__), '..', 'lib', 'jane'
+      ENV['JANE_PATH'], 'lib', 'jane'
     )
   )
 
 command =
   File.expand_path(
     File.join(
-      File.dirname(__FILE__), '..', 'lib', 'command'
+      ENV['JANE_PATH'], 'lib', 'command'
     )
   )
 
 require "json"
-require jane_lib_path
+require jane_lib
 require command
 require "net/http"
 
@@ -22,8 +22,7 @@ module Sunset
   def self.config_file
     File.expand_path(
       File.join(
-        File.dirname(__FILE__),
-        '..', 'config', 'sunset.json'
+        ENV['JANE_PATH'], 'config', 'sunset.json'
       )
     )
   end


### PR DESCRIPTION
This allows Jane to get the correct path from an env var.
Manual steps:
1. in `.bashrc` add line: `export JANE_PATH="/path/to/jane"`
2. edit crontab: `crontab -e`. at the beginning of the file add the line: `JANE_PATH="/path/to/jane"`

Not the best solution because the user needs to set JANE_PATH himself AND same information in twi places could lead to inconsistencies. But since the JANE_PATH changes very rarely, its fine for now.