### PR TITLE
fix return logic in v1 endpoint

### DIFF
--- a/jane.rb
+++ b/jane.rb
@@ -270,8 +270,9 @@ class JaneApp < Sinatra::Base
       else
         return
       end
+    else
+      Thread.new{Commander.execute(device, action)}
     end
-    Thread.new{Commander.execute(device, action)}
   end
   
   get '/job/list' do


### PR DESCRIPTION
logic in the api endpoint was broken. even if the `home` parameter was set to to true the command would be executed without the pinged device being reachable.
this branch will fix this issue.